### PR TITLE
yajl-ruby updates

### DIFF
--- a/lib/newslettre/version.rb
+++ b/lib/newslettre/version.rb
@@ -1,3 +1,3 @@
 module Newslettre
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/newslettre.gemspec
+++ b/newslettre.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "yajl-ruby", "~> 1.1.0"
-  s.add_dependency "curb", "~> 0.7"
+  s.add_dependency "curb", "~> 0.8"
 
   s.add_development_dependency "rake", "~> 0.9"
   s.add_development_dependency "rspec", "~> 2"

--- a/newslettre.gemspec
+++ b/newslettre.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "yajl-ruby", "~> 0.8"
+  s.add_dependency "yajl-ruby", "~> 1.1.0"
   s.add_dependency "curb", "~> 0.7"
 
   s.add_development_dependency "rake", "~> 0.9"


### PR DESCRIPTION
yajl-ruby has moved to 1.0+ and the gemspec for newslettre has it locked in at pre-1.0 This makes it incompatible with any gems that need > 1.0
